### PR TITLE
Fix for issues 4, 5 and 6

### DIFF
--- a/test/foursquare-locator_test.coffee
+++ b/test/foursquare-locator_test.coffee
@@ -21,19 +21,19 @@ describe 'foursquare-locator', ->
     require('../src/foursquare-locator')(@robot)
 
   it 'registers a respond listener for friends', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) friends/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:foursquare|4sq|swarm) friends/i)
 
   it 'registers a respond listener for approve', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) approve/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:foursquare|4sq|swarm) approve/i)
 
   it 'registers a respond listener for register', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) register/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:foursquare|4sq|swarm) register/i)
 
   it 'registers a respond listener for mapping user as ID', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) ([a-zA-Z0-9]+) as ([0-9]+)/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:foursquare|4sq|swarm) ([a-zA-Z0-9]+) as ([0-9]+)/i)
 
   it 'registers a respond listener for forgetting a user', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) forget ([a-zA-Z0-9]+)/i)
+    expect(@robot.respond).to.have.been.calledWith(/(?:foursquare|4sq|swarm) forget ([a-zA-Z0-9]+)/i)
 
   it 'registers a hear listener', ->
     expect(@robot.respond).to.have.been.calledWith(/where[ ']i?s ([a-zA-Z0-9 ]+)(\?)?$/i)


### PR DESCRIPTION
- Fix an issue where `!foursquare approve` seemed to do nothing (#6)
- Send user list in batches of 10 so that it doesn't run afoul of flood protection (#5)
- Fix incorrectly captured/stored data for `robot.brain` to remember who a user is. (#4)

Fixes #4
Fixes #5
Fixes #6